### PR TITLE
Add argument count validation to script

### DIFF
--- a/scripts/fedora_sync/check_fedora_sync.sh
+++ b/scripts/fedora_sync/check_fedora_sync.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# This script check the version of a package in a version of Fedora and compares it with latest
-# version in CBS for a rdo release.
+# This script check the version of a package in a version of Fedora and 
+# compares it with latest  version in CBS for a rdo release.
+
+if [[ $# -ne 4 ]]; then
+        echo "Usage: $0 <PKG> <FEDORA_RELEASE> <RDO_RELEASE>"
+        echo "E.g.: $0 python-sushy 42 caracal"
+        exit 1
+fi
 
 PKG=$1
 


### PR DESCRIPTION
   This commit adds input validation to ensure the correct number of
    arguments are provided when executing the script. 

- Checks if exactly 4 arguments are provided ($# -ne 4)
- Displays a usage message showing expected arguments: <PKG> <FEDORA_RELEASE> <RDO_RELEASE>
- Provides an example of proper usage
- Exits with error code 1 if validation fails

This helps prevent incorrect usage and makes the script more user-friendly by showing proper invocation format when arguments are missing.